### PR TITLE
ミントが出来なかった場合、ミント失敗のポップアップを表示する

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const Index = () => {
       } catch (err) {
         setMineStatus('error');
         console.log(err);
+        alert("ミント失敗！");
       }
     }
   }


### PR DESCRIPTION
feature/#9_ミント失敗ポップアップを出せる

#9 ミントが何らかの理由で成功しなかったときに、失敗した旨のポップアップを表示する。
成功したときは、ミントボタンの下に成功した旨を表示する。

close #9 