### PR TITLE
PCとスマホタブレットで表示を分けた。PCもスマホと一緒にwagmiのロジックを使用することになったのでこれは必要なくなった

### DIFF
--- a/src/CSS/App.css
+++ b/src/CSS/App.css
@@ -203,6 +203,10 @@
       padding-bottom: 10px;
       padding-left: 5px;
     }
+
+    .pc_display{
+      display: none;
+    }
   }
 
   /* 480px〜959px：タブレット
@@ -244,6 +248,10 @@
       font-weight: bold;
       padding-bottom: 10px;
       padding-left: 5px;
+    }
+
+    .pc_display{
+      display: none;
     }
   }
   
@@ -287,6 +295,10 @@
       font-weight: bold;
       padding-bottom: 10px;
       padding-left: 5px;
+    }
+
+    .sumaho_display{
+      display: none;
     }
   
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -406,6 +406,7 @@ const Index = () => {
             {renderButtun("faucet Site",false,"https://faucet.polygon.technology/")}
           </Box>
           <Box display='flex' justifyContent='center' alignItems='center' py={'3'}>
+            <div className="pc_display">
             {!currentAccount && renderButtun("Connect Wallet",true,"")}
             {currentAccount && !totalMintCount && !iaLoading &&
               <div>
@@ -428,10 +429,13 @@ const Index = () => {
               <p>Please wait just a little bit more.</p>
             </div>
             }
+            </div>
+            <div className="sumaho_display">
+              {Profile()}
+            </div>
           </Box>
         </div>
       </div>
-      {Profile()}
       {/*<div>
         {connectors.map((connector) => (
           <Button


### PR DESCRIPTION
feature/#43_PC用とスマホタブレット用の表示の切り替えをできるようにする

#43 PCとスマホタブレットで表示を分けた。PCもスマホと一緒にwagmiのロジックを使用することになったのでこれは必要なくなった

close #43 